### PR TITLE
DSD-1484: Updating readme and adding placeholder styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,146 @@
 # NYPL Header App
+
 The NYPL Header App can be used for projects across the NYPL organization to import the Header and Footer components through embeddable Javascript scripts. The Header and Footer are built with the NYPL Reservoir Design System and are hosted in this repo as React components. Dark mode for these components is available to consuming applications that use [NYPL Reservoir DS](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/welcome--page).
 
-## Running the app locally
-Install all dependencies
-```sh
-$ npm install
-```
-Builds the app into `./dist` and preview the app at `localhost:3001`
-```sh
-$ npm run prod
-```
-
-### Running the app locally with Docker
-Note: Docker needs to be installed and running on your machine in order to build the image and run the app through Docker
-
-Build the Docker image
-```sh
-$ docker build -t nypl-header-app .
-```
-This command builds the Docker image using the Dockerfile, which does the following:
-1. Creates an app directory
-2. Installs the app's dependencies via `npm install`
-3. Builds the app via `npm run prod`
-The Docker image will be named `nypl-header-app`
-
-Run the Docker instance
-```sh
-$ docker run -p 3001:3001 -d nypl-header-app
-```
-This command runs the Docker container with port mapping on 3001 ([Port access from Browser]:[Port exposed from the container]) using the Docker image above. Access the app at `localhost:3001`.
-
 ## Available Routes
-| Endpoint          | Feature|
-|:------------------|:--------------------------------------------------------|
-| `/header`         | Displays the rendered DS Header                         |
-| `/footer`         | Displays the rendered DS Footer                         |
-| `/header.min.js`  | Returns the compiled DS Header JS for the embed script. |
-| `/footer.min.js`  | Returns the compiled DS Footer JS for the embed script. |
+
+| Endpoint         | Feature                                                 |
+| :--------------- | :------------------------------------------------------ |
+| `/header`        | Displays the rendered DS Header for QA and testing.     |
+| `/footer`        | Displays the rendered DS Footer for QA and testing.     |
+| `/header.min.js` | Returns the compiled DS Header JS for the embed script. |
+| `/footer.min.js` | Returns the compiled DS Footer JS for the embed script. |
 
 ## Embeddable Scripts
+
 Any app can pull in the Header and Footer through an embeddable standalone script tag that should be used in the <body> element of the main HTML file (or any other HTML files in the app). It is suggested that the components be imported as a whole with the following markup:
 
 ```HTML
 <!-- Header -->
 <div id="nypl-header"></div>
-<script type="module" src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header" async></script> 
+<script type="module" src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header" async></script>
 
-<!-- your app content here --> 
+<!-- your app content here -->
 <main>...</main>
 
 <!-- Footer -->
 <div id="nypl-footer"></div>
-<script type="module" src="https://ds-header.nypl.org/footer.min.js?containerId=nypl-footer" async></script> 
+<script type="module" src="https://ds-header.nypl.org/footer.min.js?containerId=nypl-footer" async></script>
 ```
 
-For Next.js apps, it is recommended for the script to be added to the `_document.tsx` file for the Header and Footer components to render properly. 
+Note: this will render the components in place and will push the content down when it loads. To make it less noticeable, add placeholder styles defined below.
+
+### Next.js App Implementation
+
+For Next.js apps, it is recommended for the script to be added to the `_document.tsx` file for the Header and Footer components to render properly.
+
+### Placeholder Styles
+
+When adding the embed code snippets above, the `Header` and `Footer` will load and render in place. This means that the content below it (specifically for the `Header` since it is more visible) will be pushed down. This can be annoying but is not a bug. The app needs to call the URL, fetch the Javascript, and then render the component and how long it takes depends on the user machine's network. To help alleviate this, the app can add placeholder styles to the `Header` container to prevent the content from jumping around. The code snippet above can be updated to:
+
+```HTML
+<style>
+   #Header-Placeholder {
+      minheight: 70px;
+   }
+   @media screen and (min-width: 1024px) {
+      #Header-Placeholder {
+         min-height: 230px;
+      }
+   }
+</style>
+<!-- .... -->
+<div id="Header-Placeholder">
+   <div id="nypl-header"></div>
+   <script
+      type="module"
+      src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header"
+      async
+   ></script>
+</div>
+```
+
+#### Next.js Placement
+
+For Next.js apps, it is recommended to add the script to the `_document.tsx` file. The above `<style>` snippet will throw an error and should be updated to:
+
+```jsx
+<style>{`
+   #Header-Placeholder {
+      minheight: 70px;
+   }
+   @media screen and (min-width: 1024px) {
+      #Header-Placeholder {
+         min-height: 230px;
+      }
+   }
+`}</style>
+// ...
+<div id="Header-Placeholder">
+   <div id="nypl-header"></div>
+   <script
+      type="module"
+      src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header"
+      async
+   ></script>
+</div>
+```
+
+## Running the app locally
+
+Install all dependencies
+
+```sh
+$ npm install
+```
+
+Builds the app into `./dist` and preview the app at `localhost:3001`
+
+```sh
+$ npm run prod
+```
+
+### Running the app locally with Docker
+
+Note: Docker needs to be installed and running on your machine in order to build the image and run the app through Docker
+
+Build the Docker image
+
+```sh
+$ docker build -t nypl-header-app .
+```
+
+This command builds the Docker image using the Dockerfile, which does the following:
+
+1. Creates an app directory
+2. Installs the app's dependencies via `npm install`
+3. Builds the app via `npm run prod`
+   The Docker image will be named `nypl-header-app`
+
+Run the Docker instance
+
+```sh
+$ docker run -p 3001:3001 -d nypl-header-app
+```
+
+This command runs the Docker container with port mapping on 3001 ([Port access from Browser]:[Port exposed from the container]) using the Docker image above. Access the app at `localhost:3001`.
 
 ## Unit Testing
+
 To run all tests once:
+
 ```sh
 $ npm test
 ```
+
 If you're actively writing or updating tests, you can run the tests in watch mode. This will wait for any changes and run when a file is saved:
+
 ```sh
 $ npm run test:watch
 ```
+
 If you want to run tests on only one specific file, run:
+
 ```sh
 $ npm test -- src/[path/to/file]
 ```


### PR DESCRIPTION
This resolves [DSD-1484](https://jira.nypl.org/browse/DSD-1484).

This adds more documentation for adding placeholder style snippet to the entire embed code snippet only for the `Header`. Since the `Footer` is at the bottom of the page, it is not necessary.

This also moves the external documentation above the internal "how to run this app" documentation.