### PR TITLE
DSD-1498: Updating vite config to not use esm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The NYPL Header App can be used for projects across the NYPL organization to imp
 
 | Endpoint         | Feature                                                 |
 | :--------------- | :------------------------------------------------------ |
+| `/`              | Displays the rendered DS Header for QA and testing.     |
 | `/header`        | Displays the rendered DS Header for QA and testing.     |
 | `/footer`        | Displays the rendered DS Footer for QA and testing.     |
 | `/header.min.js` | Returns the compiled DS Header JS for the embed script. |
@@ -18,14 +19,14 @@ Any app can pull in the Header and Footer through an embeddable standalone scrip
 ```HTML
 <!-- Header -->
 <div id="nypl-header"></div>
-<script type="module" src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header" async></script>
+<script src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header" async></script>
 
 <!-- your app content here -->
 <main>...</main>
 
 <!-- Footer -->
 <div id="nypl-footer"></div>
-<script type="module" src="https://ds-header.nypl.org/footer.min.js?containerId=nypl-footer" async></script>
+<script src="https://ds-header.nypl.org/footer.min.js?containerId=nypl-footer" async></script>
 ```
 
 Note: this will render the components in place and will push the content down when it loads. To make it less noticeable, add placeholder styles defined below.
@@ -53,7 +54,6 @@ When adding the embed code snippets above, the `Header` and `Footer` will load a
 <div id="Header-Placeholder">
    <div id="nypl-header"></div>
    <script
-      type="module"
       src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header"
       async
    ></script>
@@ -79,7 +79,6 @@ For Next.js apps, it is recommended to add the script to the `_document.tsx` fil
 <div id="Header-Placeholder">
    <div id="nypl-header"></div>
    <script
-      type="module"
       src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header"
       async
    ></script>
@@ -124,6 +123,18 @@ $ docker run -p 3001:3001 -d nypl-header-app
 ```
 
 This command runs the Docker container with port mapping on 3001 ([Port access from Browser]:[Port exposed from the container]) using the Docker image above. Access the app at `localhost:3001`.
+
+## Vite Build
+
+There are three separate Vite config files that are used for building the app:
+
+- `vite.config.js` - used for building the `/`, `/header`, and `/footer` routes.
+- `vite.config.footer.js` - used for building the minified footer embed script code on the `/footer.min.js` route.
+- `vite.config.header.js` - used for building the minified header embed script code on the `/header.min.js` route.
+
+Vite can build the app using ESM output format. This is generally recommended but there are systems in place where using ESM-based `Header` and `Footer` embed scripts fail and it is out of our control. In Vite, it is not easy to build multiple dist files with multiple entry points in CJS format. To get around this, the `Header` and `Footer` builds are separate files that build a single file from a single entry point.
+
+The `Header` and `Footer` components render the same regardless of the build format.
 
 ## Unit Testing
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "NYPL Header App",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build:header": "vite build --config vite.config.header.ts --mode=production",
+    "build:footer": "vite build --config vite.config.footer.ts --mode=production",
+    "build:app": "vite build --config vite.config.ts --mode=production",
+    "build": "tsc && npm run build:header && npm run build:footer && npm run build:app",
     "preview": "vite preview",
-    "prod": "vite build --mode=production && vite preview --port 3001",
+    "prod": "npm run build && vite preview --port 3001",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,7 +15,13 @@ import HeaderSitewideAlerts from "./components/HeaderSitewideAlerts";
 import HeaderUpperNav from "./components/HeaderUpperNav";
 /** Internal Header-only utils */
 import { HeaderProvider } from "./context/headerContext";
-import { useNYPLBreakpoints, SkipNavigation, Link, Logo, HorizontalRule } from "@nypl/design-system-react-components";
+import {
+  useNYPLBreakpoints,
+  SkipNavigation,
+  Link,
+  Logo,
+  HorizontalRule,
+} from "@nypl/design-system-react-components";
 
 export interface HeaderProps {
   /** Whether to render sitewide alerts or not. True by default. */
@@ -30,10 +36,7 @@ export interface HeaderProps {
  * the NYPL.org site.
  */
 export const Header = chakra(
-  ({
-    fetchSitewideAlerts = true,
-    isProduction = true,
-  }: HeaderProps) => {
+  ({ fetchSitewideAlerts = true, isProduction = true }: HeaderProps) => {
     const { isLargerThanMobile, isLargerThanLarge } = useNYPLBreakpoints();
     const styles = useMultiStyleConfig("Header", {});
 

--- a/src/footer/FooterApp.tsx
+++ b/src/footer/FooterApp.tsx
@@ -1,9 +1,7 @@
-import {
-  DSProvider
-} from "@nypl/design-system-react-components";
+import { DSProvider } from "@nypl/design-system-react-components";
 import Footer from "../components/Footer/Footer";
 
-const FooterApp: any = ({ isTestMode = false }): any => {
+const FooterApp: any = (): any => {
   return (
     <DSProvider>
       <Footer />

--- a/vite.config.footer.ts
+++ b/vite.config.footer.ts
@@ -1,0 +1,41 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import svgr from "vite-plugin-svgr";
+
+const root = resolve(__dirname, "src");
+const outDir = resolve(__dirname, "dist");
+
+// This is a separate Vite config file for the Footer. This is done because
+// we want the /footer.min.js endpoint to contain all the code for the Footer
+// and Vite does not allow a single file when multiple entry points are set.
+module.exports = defineConfig({
+  server: {
+    host: true, // for Docker Container port mapping
+  },
+  plugins: [
+    react(),
+    svgr({
+      svgrOptions: {
+        titleProp: true,
+      },
+    }),
+  ],
+  root,
+  build: {
+    outDir,
+    rollupOptions: {
+      input: {
+        "footer.min": resolve(root, "footer", "main.tsx"),
+      },
+      output: {
+        entryFileNames: "[name].js",
+        // ESM is not supported everywhere yet for various reasons, so build
+        // the bundle in IIFE (Immediately Invoked Function Expression)
+        // format. The entire file will be wrapped in a single function call
+        // that will be executed as soon as the browser downloads the bundle.
+        format: "iife",
+      },
+    },
+  },
+});

--- a/vite.config.header.ts
+++ b/vite.config.header.ts
@@ -1,0 +1,41 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import svgr from "vite-plugin-svgr";
+
+const root = resolve(__dirname, "src");
+const outDir = resolve(__dirname, "dist");
+
+// This is a separate Vite config file for the Header. This is done because
+// we want the /header.min.js endpoint to contain all the code for the Header
+// and Vite does not allow a single file when multiple entry points are set.
+module.exports = defineConfig({
+  server: {
+    host: true, // for Docker Container port mapping
+  },
+  plugins: [
+    react(),
+    svgr({
+      svgrOptions: {
+        titleProp: true,
+      },
+    }),
+  ],
+  root,
+  build: {
+    outDir,
+    rollupOptions: {
+      input: {
+        "header.min": resolve(root, "header", "main.tsx"),
+      },
+      output: {
+        entryFileNames: "[name].js",
+        // ESM is not supported everywhere yet for various reasons, so build
+        // the bundle in IIFE (Immediately Invoked Function Expression)
+        // format. The entire file will be wrapped in a single function call
+        // that will be executed as soon as the browser downloads the bundle.
+        format: "iife",
+      },
+    },
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { resolve } from 'path';
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 
 const root = resolve(__dirname, "src");
@@ -16,23 +16,20 @@ module.exports = defineConfig({
       svgrOptions: {
         titleProp: true,
       },
-    })
+    }),
   ],
   root,
   build: {
     outDir,
-    emptyOutDir: true,
     rollupOptions: {
       input: {
         ".": resolve(root, "index.html"),
         header: resolve(root, "header", "index.html"),
         footer: resolve(root, "footer", "index.html"),
-        "header.min": resolve(root, "header", "main.tsx"),
-        "footer.min": resolve(root, "footer", "main.tsx"),
       },
       output: {
         entryFileNames: "[name].js",
-      }
+      },
     },
   },
 });


### PR DESCRIPTION
Resolves [DSD-1498](https://jira.nypl.org/browse/DSD-1498).

We found out that using ESM is not the right approach for the minified files to use in the embed script.
- Vega _seems_ to remove the `type="module"` and `async` attributes and this does not allow the URL to load. They also have CORS set up which adds to the inability to fetch, load, and render the `Header` component.
- `type="module"` also does not seem to work on VPN. Is it specifically our VPN and its configuration or any VPN? That's not clear. But because using VPN and navigating NYPL would not render the `Header`, it is another good point to not use ESM.

This update separates the Vite config into three separate files:
- one for the minified Header `/header.min.js`,
- one for the minified Footer `/footer.min.js`,
- one for the component preview endpoints (`/`, `/header`, `/footer`)

They are now separate because Vite cannot compile the minified files (all the code into a single file) when there are multiple entry points. I think this is because it tries to optimize the build by tree shaking and using asset files -- but we don't want that in this case.

We will also no longer suggest adding `type="module"` in the embed script and the README has been updated.