### PR TITLE
Typo fix for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When adding the embed code snippets above, the `Header` and `Footer` will load a
 ```HTML
 <style>
    #Header-Placeholder {
-      minheight: 70px;
+      min-height: 70px;
    }
    @media screen and (min-width: 1024px) {
       #Header-Placeholder {
@@ -67,7 +67,7 @@ For Next.js apps, it is recommended to add the script to the `_document.tsx` fil
 ```jsx
 <style>{`
    #Header-Placeholder {
-      minheight: 70px;
+      min-height: 70px;
    }
    @media screen and (min-width: 1024px) {
       #Header-Placeholder {


### PR DESCRIPTION
The `minHeight` name is correct but only for Chakra and not for browsers. This is meant for any app and not just Chakra-based ones.