### PR TITLE
DSD-1534: Adding skip nav focus link styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 7/19
+
+### Fixes
+
+- Adds explicit focus styles for the skip nav links. They were inadvertently
+  removed when the global styles were disabled.
+
 ## 6/13
 
 ### Adds

--- a/src/theme/header.ts
+++ b/src/theme/header.ts
@@ -30,6 +30,18 @@ const Header = {
       boxSizing: "border-box",
     },
     "& > nav li": { marginBottom: "0 !important" },
+    "& > nav a": {
+      _focus: {
+        boxShadow: "none",
+        outline: "2px solid",
+        outlineOffset: "2px",
+        outlineColor: "ui.focus",
+        zIndex: "9999",
+        _dark: {
+          outlineColor: "dark.ui.focus",
+        },
+      },
+    },
     "& svg": { verticalAlign: "baseline !important" },
     button: {
       cursor: "pointer",


### PR DESCRIPTION
Fixes [JIRA ticket DSD-1534](http://jira.nypl.org/browse/DSD-1534)

## This PR does the following:

- When the DS global style rules were disabled, the link's focus styles were removed. This affected the skip navigation's links; when they were focused they stayed hidden. This PR explicitly adds the rules so they appear when tabbed to.

## How has this been tested?

Locally. Test by tabbing from the start of the document:
<img width="1022" alt="Screen Shot 2023-07-19 at 4 43 01 PM" src="https://github.com/NYPL/nypl-header-app/assets/1280564/0928eac4-4fe5-4f3b-b48f-960f6463f95b">


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.