### PR TITLE
Hotfix: Updating email newsletter URL

### DIFF
--- a/src/components/Header/components/__snapshots__/HeaderMobileNav.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/HeaderMobileNav.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`HeaderMobileNav renders the UI snapshot correctly 1`] = `
     </a>
     <a
       className="css-1i5qkun"
-      href="https://pages.email.nypl.org/page.aspx?QS=3935619f7de112ef7250fe02b84fb2f9ab74e4ea015814b7"
+      href="https://pub.email.nypl.org/subscriptioncenter"
       rel={null}
       target={null}
     >

--- a/src/components/Header/utils/headerUtils.ts
+++ b/src/components/Header/utils/headerUtils.ts
@@ -63,7 +63,7 @@ export const upperNavLinks = {
     text: "Get A Library Card",
   },
   emailUpdates: {
-    href: "https://pages.email.nypl.org/page.aspx?QS=3935619f7de112ef7250fe02b84fb2f9ab74e4ea015814b7",
+    href: "https://pub.email.nypl.org/subscriptioncenter",
     text: "Get Email Updates",
   },
   donate: {


### PR DESCRIPTION
## This PR does the following:

- Updates the URL for the "Get Email Updates" button in the top nav.
- Confirmed with Allison Palmer that `https://pub.email.nypl.org/subscriptioncenter` is the correct URL to use.

## How has this been tested?

Locally.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.