### PR TITLE
Routines for previous image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jobs:
         - if [[ $TRAVIS_BRANCH == "qa" ]]; then export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_DEVELOPMENT;
           export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_DEVELOPMENT; export ENV="qa";
           export ECR_URL=491147561046.dkr.ecr.us-east-1.amazonaws.com/nyplglobalheader;
+          export ECR_REPO=nyplglobalheader
           fi
         - if [[ "$TRAVIS_BRANCH" == "production" ]]; then export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_PRODUCTION;
           export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_PRODUCTION; export ENV="production";
@@ -30,6 +31,9 @@ jobs:
         - aws ecr get-login-password --region us-east-1 | docker login --password-stdin --username AWS $ECR_URL
         - DOCKER_BUILDKIT=1 docker build -t "$LOCAL_TAG_NAME" --secret id=AWS_ACCESS_KEY_ID
           --secret id=AWS_SECRET_ACCESS_KEY .
+        - MANIFEST=$(aws ecr batch-get-image --repository-name $ECR_REPO --image-ids imageTag="$ENV-latest" --output json | jq --raw-output --join-output '.images[0].imageManifest')
+          aws ecr batch-delete-image --repository-name $ECR_REPO --image-ids imageTag="$ENV-previous" || true
+          aws ecr put-image --repository-name $ECR_REPO --image-tag "$ENV-previous" --image-manifest "$MANIFEST"
         - docker tag "$LOCAL_TAG_NAME" "$ECR_URL:$LOCAL_TAG_NAME"
         - docker push "$ECR_URL:$LOCAL_TAG_NAME"
     - stage: deploy qa
@@ -39,10 +43,13 @@ jobs:
         - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_DEVELOPMENT
         - AWS_DEFAULT_REGION=us-east-1
         - AWS_REGION=us-east-1
+        - PREVIOUS_CLUSTER_NAME=nyplorg-globalheader-previous-qa
         - CLUSTER_NAME=nyplorg-globalheader-qa
       install:
         - pip install --user awscli
       script:
+        - aws ecs update-service --cluster $PREVIOUS_CLUSTER_NAME --service $PREVIOUS_CLUSTER_NAME --force-new-deployment
+        - aws ecs wait services-stable --cluster $PREVIOUS_CLUSTER_NAME --services $PREVIOUS_CLUSTER_NAME
         - aws ecs update-service --cluster $CLUSTER_NAME --service $CLUSTER_NAME --force-new-deployment
     - stage: deploy production
       if: branch IN (production) AND type != pull_request
@@ -51,10 +58,13 @@ jobs:
         - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_PRODUCTION
         - AWS_DEFAULT_REGION=us-east-1
         - AWS_REGION=us-east-1
+        - PREVIOUS_CLUSTER_NAME=nyplorg-globalheader-previous-production
         - CLUSTER_NAME=nyplorg-globalheader-production
       install:
         - pip install --user awscli
       script:
+        - aws ecs update-service --cluster $PREVIOUS_CLUSTER_NAME --service $PREVIOUS_CLUSTER_NAME --force-new-deployment
+        - aws ecs wait services-stable --cluster $PREVIOUS_CLUSTER_NAME --services $PREVIOUS_CLUSTER_NAME
         - aws ecs update-service --cluster $CLUSTER_NAME --service $CLUSTER_NAME --force-new-deployment
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 9/21
+
+- Adds commands to copy the latest Docker image on ECR to a previous image before pushing the latest image
+- Adds commands for Travis to initiate changes to the fallback stack
+
 ## 9/14
 
 ### Updates


### PR DESCRIPTION
Relates to [JIRA ticket SEB-2658](http://jira.nypl.org/browse/SEB-2658)
Relates to [JIRA ticket SEB-2659](http://jira.nypl.org/browse/SEB-2659)

## This PR does the following:

- Adds AWS API commands to copy the currently deploy Docker image (-latest) to an image for the fallback stack (-previous) before the latest image is pushed
- Adds an AWS API command to restart the fallback stack with the new, previous image
- Adds an AWS API command to wait till the fallback stack is stable before restarting the live stack
- Updates to the fallback ECS stack are necessary to use this new, previous image

## How has this been tested?

This should be tested in changes to the QA stack which can be minor, inconsequential changes to determine the effectiveness of this change.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.