### PR TITLE
Updates encoding functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 3/26
+
+### Fixes
+
+- Fixes search term encoding so that vega can properly consume the query
+
 ## 1/10/24
 
 ### Updates
@@ -16,7 +22,8 @@
 
 ## 9/21
 
-- Adds commands to copy the latest Docker image on ECR to a previous image before pushing the latest image
+- Adds commands to copy the latest Docker image on ECR to a previous image
+  before pushing the latest image
 - Adds commands for Travis to initiate changes to the fallback stack
 
 ## 9/14
@@ -24,7 +31,8 @@
 ### Updates
 
 - Updates the DS version to `1.7.3`.
-- Updates the breakpoints, spacing, font size, icons, and colors to the mobile and desktop header. This is a general UI update for minor visual improvements.
+- Updates the breakpoints, spacing, font size, icons, and colors to the mobile
+  and desktop header. This is a general UI update for minor visual improvements.
 
 ## 8/22
 
@@ -45,8 +53,8 @@
 
 ### Adds
 
-- Adds style files for the `Header` and `Footer` component. A new theme file
-  is created and passed to the `DSProvider` component.
+- Adds style files for the `Header` and `Footer` component. A new theme file is
+  created and passed to the `DSProvider` component.
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 3/26
+## Unreleased
 
 ### Fixes
 

--- a/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`Footer renders the UI snapshot correctly 1`] = `
     >
       <p>
         © The New York Public Library, 
-        2023
+        2024
       </p>
       <p>
         The New York Public Library is a 501(c)(3) | EIN 13-1887440

--- a/src/components/Header/utils/headerUtils.test.ts
+++ b/src/components/Header/utils/headerUtils.test.ts
@@ -1,31 +1,11 @@
 import {
-  encoreEncodeSearchString,
+  // encoreEncodeSearchString,
   getEncoreCatalogURL,
   getNYPLSearchURL,
   getResearchCatalogURL,
 } from "./headerUtils";
 
 describe("Header utils", () => {
-  describe("encoreEncodeSearchString", () => {
-    it("should encode a search string", () => {
-      const searchString = "foo bar";
-      const encodedSearchString = encoreEncodeSearchString(searchString);
-      expect(encodedSearchString).toEqual("foo bar");
-    });
-
-    it("should encode a search string with special characters", () => {
-      const searchString = "foo bar/\\?=";
-      const encodedSearchString = encoreEncodeSearchString(searchString);
-      expect(encodedSearchString).toEqual("foo bar/\\Pw===");
-    });
-
-    it("should encode a search string with special characters and spaces", () => {
-      const searchString = "foo bar/\\?= foo bar";
-      const encodedSearchString = encoreEncodeSearchString(searchString);
-      expect(encodedSearchString).toEqual("foo bar/\\Pw=== foo bar");
-    });
-  });
-
   describe("getEncoreCatalogURL", () => {
     const currentDate = new Date("2022-01-01");
     let realDate;

--- a/src/components/Header/utils/headerUtils.test.ts
+++ b/src/components/Header/utils/headerUtils.test.ts
@@ -27,7 +27,7 @@ describe("Header utils", () => {
       const searchValue = "foo bar";
       const url = getEncoreCatalogURL(searchValue);
       expect(url).toEqual(
-        "https://browse.nypl.org/iii/encore/search/C__Sfoo bar__Orightresult__U?searched_from=header_search&timestamp=1640995200000&lang=eng"
+        "https://browse.nypl.org/iii/encore/search/C__Sfoo%20bar__Orightresult__U?searched_from=header_search&timestamp=1640995200000&lang=eng"
       );
     });
 
@@ -35,7 +35,7 @@ describe("Header utils", () => {
       const searchValue = "foo bar/\\?=";
       const url = getEncoreCatalogURL(searchValue);
       expect(url).toEqual(
-        "https://browse.nypl.org/iii/encore/search/C__Sfoo bar/\\Pw===__Orightresult__U?searched_from=header_search&timestamp=1640995200000&lang=eng"
+        "https://browse.nypl.org/iii/encore/search/C__Sfoo%20bar%2F%5C%3F%3D__Orightresult__U?searched_from=header_search&timestamp=1640995200000&lang=eng"
       );
     });
   });

--- a/src/components/Header/utils/headerUtils.test.ts
+++ b/src/components/Header/utils/headerUtils.test.ts
@@ -1,5 +1,4 @@
 import {
-  // encoreEncodeSearchString,
   getEncoreCatalogURL,
   getNYPLSearchURL,
   getResearchCatalogURL,

--- a/src/components/Header/utils/headerUtils.ts
+++ b/src/components/Header/utils/headerUtils.ts
@@ -107,33 +107,6 @@ export const siteNavLinks = [
 ];
 
 /**
- * Replaces the search string's special characters that need to be encoded
- * using base64. These characters are "=","/", "\", "?".
- */
-export const encoreEncodeSearchString = (searchString) => {
-  const base64EncodeMap = {
-    "=": "PQ==",
-    "/": "Lw==",
-    "\\": "XA==",
-    "?": "Pw==",
-  };
-  let encodedSearchString = searchString;
-  Object.keys(base64EncodeMap).forEach((specialChar) => {
-    const charRegExString = specialChar.replace(
-      /([\.\*\+\?\^\=\!\:\$\{\}\(\)\|\[\]\/\\])/g,
-      "\\$1"
-    );
-    const base64Regex = new RegExp(charRegExString, "g");
-    encodedSearchString = searchString.replace(
-      base64Regex,
-      base64EncodeMap[specialChar]
-    );
-  });
-
-  return encodedSearchString;
-};
-
-/**
  * Generates the queries to be added to the URL of the search pages.
  */
 const generateQueriesForTracking = () => {
@@ -146,7 +119,7 @@ const generateQueriesForTracking = () => {
  * Returns the final URL for the NYPL Encore search.
  */
 export const getEncoreCatalogURL = (searchValue) => {
-  const encodedSearchInput = encoreEncodeSearchString(searchValue);
+  const encodedSearchInput = encodeURIComponent(searchValue);
   const rootUrl = "https://browse.nypl.org/iii/encore/search/";
   let finalEncoreUrl;
 


### PR DESCRIPTION
Fixes [DSD-1727](https://jira.nypl.org/browse/DSD-1727)

## This PR does the following:

- Fixes search term encoding so that vega can properly consume the query
- Seems like we no longer need custom encoding, the built-in `encodeURIComponent` works as expected
- You can test by typing a search term like, "? cat" or "/" and ensuring the same search term is shown in the vega search input and that the results are as expected.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

- Locally

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.