### PR TITLE
Add symlink for older header JS file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm install
 RUN npm rebuild esbuild
 # Copy source code to /app directory
 COPY . ./
+RUN ln -s /app/dist/header.min.js /app/dist/dgx-header.min.js
 # Expose port 4173 on container
 EXPOSE 4173
 # Build and run the app


### PR DESCRIPTION
Fixes [JIRA ticket DSD-753](https://jira.nypl.org/browse/DSD-1753)

## This PR does the following:

- Work by @gkallenberg 
- Adds a symlink command to the Dockerfile which will point from the old javascript path to the javascript path used by the new DS Header.
- https://docs.google.com/document/d/1jILYPrcSC1ljeKXDfNDkHgHtqh3vL8WKYyLUFrOw72c/edit

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.