### PR TITLE
DSD-1753: Adds !important to certain styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Updates
 
 - Removes fallback font options so footer inherits from the DS.
+- Adds `!important` designation to header font sizes so consuming app styles
+  don't override it.
 
 ## 5/16/24
 

--- a/src/theme/headerLowerNav.ts
+++ b/src/theme/headerLowerNav.ts
@@ -27,7 +27,7 @@ const HeaderLowerNav = {
     "li > a": {
       color: "ui.black",
       fontSize: {
-        base: "desktop.subtitle.subtitle2",
+        base: "var(--nypl-fontSizes-desktop-subtitle-subtitle2) !important",
         lh: "desktop.subtitle.subtTitle1",
       },
       fontWeight: "medium",

--- a/src/theme/headerSearchButton.ts
+++ b/src/theme/headerSearchButton.ts
@@ -8,7 +8,7 @@ const HeaderSearchButton = {
     color: isOpen ? "ui.white" : "ui.link.primary",
     display: "flex",
     fontFamily: "body",
-    fontSize: "inherit",
+    fontSize: "inherit !important",
     fontWeight: "medium",
     justifyContent: "center",
     minHeight: { mh: "30px" },

--- a/src/theme/headerUpperNav.ts
+++ b/src/theme/headerUpperNav.ts
@@ -1,4 +1,4 @@
-import { headerFocus, headerRed } from "./header";
+import { headerFocus } from "./header";
 
 const HeaderUpperNav = {
   parts: ["donateLink"],
@@ -11,7 +11,7 @@ const HeaderUpperNav = {
       whiteSpace: "nowrap",
     },
     li: {
-      fontSize: "desktop.body.body2",
+      fontSize: "var(--nypl-fontSizes-desktop-body-body2) !important",
       fontWeight: "medium",
       marginRight: "s",
       _last: {


### PR DESCRIPTION
Fixes [DSD-1753](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1753)

## This PR does the following:

- Adds !important designation to certain styles to keep them from being overridden in consuming app.
- Screenshot showing the problem in the libguides app (small font)
![Uploading Screenshot 2024-06-18 at 4.00.39 PM.png…]()


## How has this been tested?

- Locally
- Will also need to be tested in a consuming application 

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.

[DSD-1753]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ