### PR TITLE
Updates code so libguides base font is 16px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removes fallback font options so footer inherits from the DS.
 - Adds `!important` designation to header font sizes so consuming app styles
   don't override it.
+- Ensures libguides base font is 16px so header appears correctly.
 
 ## 5/16/24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Removes fallback font options so footer inherits from the DS.
 - Adds `!important` designation to header font sizes so consuming app styles
   don't override it.
-- Ensures libguides base font is 16px so header appears correctly.
+- Ensures consuming app, libguides, has base font of 16px so header appears
+  correctly.
 
 ## 5/16/24
 

--- a/src/header/main.tsx
+++ b/src/header/main.tsx
@@ -34,10 +34,11 @@ const getQueryParam = (fullUrl = "", variableToFind: string) => {
     } else {
       document.addEventListener("DOMContentLoaded", fn);
     }
-    // This is to set the font size to 1em on the HTML element for sites
-    // that may have a different base font size, such as "62.5%".
-    if (window.location.origin.includes("vega")) {
-      document.getElementsByTagName("html")[0].style.fontSize = "1em";
+    // Sets the base font size to 16px for libguides.nypl.org;
+    // (it's currently set to 10px which interferes with how the header
+    // is meant to look)
+    if (window.location.origin.includes("libguides")) {
+      document.getElementsByTagName("html")[0].style.fontSize = "16px";
     }
   }
   function header() {


### PR DESCRIPTION
Fixes [JIRA ticket DSD-1753](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1753)

## This PR does the following:

- Ensures consuming app, libguides, has base font of 16px so header appears correctly.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.