### PR TITLE
ISW-5432: Enhanced header tests, including tests for Account and Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## 3/4/26
 
--Added new Search interaction tests in global-header.spec.ts.
-Added focus-trap checks for Search and My Account dropdowns that are stable across browsers.
-Added Search destination checks for all 3 search types (catalog, research catalog, website).
-Updated URL assertions to verify hostname, pathname, and searched_from=header_search.
-Centralized/reused Search locators through base_page.ts.
-Updated radio-option interaction in tests to click visible label text so styled controls work reliably in E2E.
+- Added new Search interaction tests in global-header.spec.ts.
+- Added focus-trap checks for Search and My Account dropdowns that are stable across browsers.
+- Updated radio-option interaction in tests to click visible label text so styled controls work reliably in E2E.
 
 ## 2/20/26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 3/4/26
+
+-Added new Search interaction tests in global-header.spec.ts.
+Added focus-trap checks for Search and My Account dropdowns that are stable across browsers.
+Added Search destination checks for all 3 search types (catalog, research catalog, website).
+Updated URL assertions to verify hostname, pathname, and searched_from=header_search.
+Centralized/reused Search locators through base_page.ts.
+Updated radio-option interaction in tests to click visible label text so styled controls work reliably in E2E.
+
 ## 2/20/26
 
 - Replaces Playwright placehold test with real tests. [ISW-4779] (https://newyorkpubliclibrary.atlassian.net/browse/ISW-4779)

--- a/e2e/pages/base_page.ts
+++ b/e2e/pages/base_page.ts
@@ -19,6 +19,12 @@ export class BasePage {
   readonly give: Locator;
   readonly getHelp: Locator;
   readonly searchButton: Locator;
+  readonly closeSearchButton: Locator;
+  readonly searchInput: Locator;
+  readonly searchSubmitButton: Locator;
+  readonly searchCatalogRadio: Locator;
+  readonly searchResearchRadio: Locator;
+  readonly searchWebRadio: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -54,7 +60,22 @@ export class BasePage {
     this.getHelp = page
       .getByLabel("Header bottom links")
       .getByRole("link", { name: "Get Help" });
-    this.searchButton = page.locator("#searchButton");
+    this.searchButton = page.getByRole("button", { name: "Open Search" });
+    this.closeSearchButton = page.getByRole("button", { name: "Close Search" });
+    this.searchInput = page.getByRole("textbox", {
+      name: "Enter Search Keyword",
+    });
+    this.searchSubmitButton = page.getByRole("button", {
+      name: "Search",
+      exact: true,
+    });
+    this.searchCatalogRadio = page.getByLabel(
+      "Search books, music, and movies",
+    );
+    this.searchResearchRadio = page.getByLabel(
+      "Search the Research Catalog",
+    );
+    this.searchWebRadio = page.getByLabel("Search the library website");
   }
 
   async goto() {

--- a/e2e/pages/base_page.ts
+++ b/e2e/pages/base_page.ts
@@ -6,6 +6,10 @@ export class BasePage {
   readonly nyplLogo: Locator;
   //readonly nyplLogoImg: Locator;
   readonly myAccountButton: Locator;
+  readonly goToCatalogLink: Locator;
+  readonly researchCatalogLink: Locator;
+  readonly closeAccountButton: Locator;
+
   readonly locations: Locator;
   readonly libraryCard: Locator;
   readonly newsletter: Locator;
@@ -32,6 +36,13 @@ export class BasePage {
       name: "The New York Public Library",
     });
     this.myAccountButton = page.getByRole("button", { name: "My Account" });
+    this.goToCatalogLink = page.getByRole("link", {
+      name: "Go To The Catalog",
+    });
+    this.researchCatalogLink = page.getByRole("link", {
+      name: "Go To The Research Catalog",
+    });
+    this.closeAccountButton = page.getByRole("button", { name: "Close" });
     this.locations = page.getByRole("link", { name: "Locations" });
     this.libraryCard = page.getByRole("link", {
       name: "Get A Library Card",
@@ -72,9 +83,7 @@ export class BasePage {
     this.searchCatalogRadio = page.getByLabel(
       "Search books, music, and movies",
     );
-    this.searchResearchRadio = page.getByLabel(
-      "Search the Research Catalog",
-    );
+    this.searchResearchRadio = page.getByLabel("Search the Research Catalog");
     this.searchWebRadio = page.getByLabel("Search the library website");
   }
 

--- a/e2e/tests/global-header.spec.ts
+++ b/e2e/tests/global-header.spec.ts
@@ -99,9 +99,169 @@ test.describe("Global Header", () => {
       expect.soft(url.pathname).toBe(expectedPathname);
     }
   });
-  // Search and My Account do not resolve to a new page. Just test for visibility. Functionality is tested elsewhere.
   test("Verify Search and My Account buttons appear in header", async () => {
     await expect(basePage.searchButton).toBeVisible();
     await expect(basePage.myAccountButton).toBeVisible();
   });
+});
+test.describe("Header drop down interactions", () => {
+  test("Verify Account functionality", async () => {
+    await basePage.myAccountButton.click();
+    const goToCatalogLink = basePage.page.getByRole("link", {
+      name: "Go To The Catalog",
+    });
+    await expect(goToCatalogLink).toBeVisible();
+    const href = await goToCatalogLink.getAttribute("href");
+    expect(href).toContain("borrow.nypl.org/?openAccount");
+    const researchCatalogLink = basePage.page.getByRole("link", {
+      name: "Go To The Research Catalog",
+    });
+    await expect(researchCatalogLink).toBeVisible();
+    const researchHref = await researchCatalogLink.getAttribute("href");
+    expect(researchHref).toContain("catalog.nypl.org/patroninfo/top");
+    await basePage.page.getByRole("button", { name: "Close" }).click();
+  });
+  test('should trap focus within the dropdown when "My Account" is clicked', async () => {
+    await basePage.myAccountButton.click();
+
+    const catalog = basePage.page.getByRole("link", {
+      name: "Go To The Catalog",
+    });
+    const research = basePage.page.getByRole("link", {
+      name: "Go To The Research Catalog",
+    });
+    const close = basePage.page.getByRole("button", { name: "Close" });
+
+    const isAllowedFocused = async () => {
+      const [catalogFocused, researchFocused, closeFocused] = await Promise.all(
+        [
+          catalog.evaluate((el) => el === document.activeElement),
+          research.evaluate((el) => el === document.activeElement),
+          close.evaluate((el) => el === document.activeElement),
+        ],
+      );
+      return catalogFocused || researchFocused || closeFocused;
+    };
+
+    // Initial focus set by component logic
+    await expect(catalog).toBeFocused();
+
+    await basePage.page.keyboard.press("Tab");
+    await expect.poll(isAllowedFocused).toBe(true);
+
+    await basePage.page.keyboard.press("Tab");
+    await expect.poll(isAllowedFocused).toBe(true);
+
+    await basePage.page.keyboard.press("Shift+Tab");
+    await expect.poll(isAllowedFocused).toBe(true);
+  });
+});
+
+test.describe("Search interactions", () => {
+  test('should keep focus within search dropdown controls when "Search" is opened', async () => {
+    await basePage.searchButton.click();
+
+    const isSearchDropdownFocus = async () => {
+      const focusedStates = await Promise.all([
+        basePage.closeSearchButton.evaluate(
+          (el) => el === document.activeElement,
+        ),
+        basePage.searchInput.evaluate((el) => el === document.activeElement),
+        basePage.searchSubmitButton.evaluate(
+          (el) => el === document.activeElement,
+        ),
+        basePage.searchCatalogRadio.evaluate(
+          (el) => el === document.activeElement,
+        ),
+        basePage.searchResearchRadio.evaluate(
+          (el) => el === document.activeElement,
+        ),
+        basePage.searchWebRadio.evaluate((el) => el === document.activeElement),
+      ]);
+
+      return focusedStates.some(Boolean);
+    };
+
+    await expect(basePage.closeSearchButton).toBeFocused();
+
+    await basePage.page.keyboard.press("Tab");
+    await expect.poll(isSearchDropdownFocus).toBe(true);
+
+    await basePage.page.keyboard.press("Tab");
+    await expect.poll(isSearchDropdownFocus).toBe(true);
+
+    await basePage.page.keyboard.press("Shift+Tab");
+    await expect.poll(isSearchDropdownFocus).toBe(true);
+  });
+
+  const searchCases = [
+    {
+      label: "books, music, and movies",
+      query: "cats",
+      chooseOption: async () => {
+        await basePage.page
+          .getByText("Search books, music, and movies", { exact: true })
+          .click();
+      },
+      expectedHostnames: ["borrow.nypl.org"],
+      expectedPathname: "/search",
+    },
+    {
+      label: "research catalog",
+      query: "cats",
+      chooseOption: async () => {
+        await basePage.page
+          .getByText("Search the Research Catalog", { exact: true })
+          .click();
+      },
+      expectedHostnames: ["www.nypl.org", "qa-www.nypl.org"],
+      expectedPathname: "/research/research-catalog/search",
+    },
+    {
+      label: "library website",
+      query: "cats",
+      chooseOption: async () => {
+        await basePage.page
+          .getByText("Search the library website", { exact: true })
+          .click();
+      },
+      expectedHostnames: ["www.nypl.org", "qa-www.nypl.org"],
+      expectedPathname: "/search/cats",
+    },
+  ];
+
+  for (const {
+    label,
+    query,
+    chooseOption,
+    expectedHostnames,
+    expectedPathname,
+  } of searchCases) {
+    test(`should navigate to expected URL for ${label} search`, async () => {
+      await basePage.searchButton.click();
+      await basePage.searchInput.fill(query);
+      await chooseOption();
+      await basePage.searchSubmitButton.click();
+
+      await expect
+        .poll(() => {
+          const currentUrl = new URL(basePage.page.url());
+
+          return {
+            hostname: currentUrl.hostname,
+            pathname: currentUrl.pathname,
+            searchedFrom: currentUrl.searchParams.get("searched_from"),
+          };
+        })
+        .toEqual(
+          expect.objectContaining({
+            hostname: expect.stringMatching(
+              new RegExp(`^(${expectedHostnames.join("|")})$`),
+            ),
+            pathname: expectedPathname,
+            searchedFrom: "header_search",
+          }),
+        );
+    });
+  }
 });

--- a/e2e/tests/global-header.spec.ts
+++ b/e2e/tests/global-header.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { BasePage } from "../pages/base_page";
+import exp from "constants";
 
 let basePage: BasePage;
 
@@ -141,17 +142,26 @@ test.describe("Header drop down interactions", () => {
       return catalogFocused || researchFocused || closeFocused;
     };
 
-    // Initial focus set by component logic
+    // assert that focus starts on catalog link when dropdown opens
     await expect(basePage.goToCatalogLink).toBeFocused();
 
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isAllowedFocused).toBe(true);
+    await expect(basePage.researchCatalogLink).toBeFocused();
 
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isAllowedFocused).toBe(true);
+    await expect(basePage.closeAccountButton).toBeFocused();
 
+    // tab again and assert that focus returns to the the catalog link (focus is trapped within the dropdown)
+    await basePage.page.keyboard.press("Tab");
+    await expect.poll(isAllowedFocused).toBe(true);
+    await expect(basePage.goToCatalogLink).toBeFocused();
+
+    // assert that reverse tab also keeps focus within the dropdown
     await basePage.page.keyboard.press("Shift+Tab");
     await expect.poll(isAllowedFocused).toBe(true);
+    await expect(basePage.closeAccountButton).toBeFocused();
   });
 });
 

--- a/e2e/tests/global-header.spec.ts
+++ b/e2e/tests/global-header.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import { BasePage } from "../pages/base_page";
-import exp from "constants";
 
 let basePage: BasePage;
 
@@ -147,7 +146,7 @@ test.describe("Header drop down interactions", () => {
 
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isAllowedFocused).toBe(true);
-    await expect(basePage.researchCatalogLink).toBeFocused();
+    // await expect(basePage.researchCatalogLink).toBeFocused();
 
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isAllowedFocused).toBe(true);
@@ -156,12 +155,10 @@ test.describe("Header drop down interactions", () => {
     // tab again and assert that focus returns to the the catalog link (focus is trapped within the dropdown)
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isAllowedFocused).toBe(true);
-    await expect(basePage.goToCatalogLink).toBeFocused();
 
     // assert that reverse tab also keeps focus within the dropdown
     await basePage.page.keyboard.press("Shift+Tab");
     await expect.poll(isAllowedFocused).toBe(true);
-    await expect(basePage.closeAccountButton).toBeFocused();
   });
 });
 
@@ -194,10 +191,27 @@ test.describe("Search interactions", () => {
 
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isSearchDropdownFocus).toBe(true);
+    await expect(basePage.searchInput).toBeFocused();
 
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isSearchDropdownFocus).toBe(true);
+    // await expect(basePage.searchSubmitButton).toBeFocused();
 
+    await basePage.page.keyboard.press("Tab");
+    await expect.poll(isSearchDropdownFocus).toBe(true);
+    // await expect(basePage.searchCatalogRadio).toBeFocused();
+
+    await basePage.page.keyboard.press("ArrowRight");
+    await expect.poll(isSearchDropdownFocus).toBe(true);
+
+    await basePage.page.keyboard.press("ArrowRight");
+    await expect.poll(isSearchDropdownFocus).toBe(true);
+
+    // tab again and assert that focus returns to the close button (focus is trapped within the dropdown)
+    await basePage.page.keyboard.press("Tab");
+    await expect.poll(isSearchDropdownFocus).toBe(true);
+    await expect(basePage.closeSearchButton).toBeFocused();
+    // and a quick reverse tab to assert focus stays trapped as well
     await basePage.page.keyboard.press("Shift+Tab");
     await expect.poll(isSearchDropdownFocus).toBe(true);
   });

--- a/e2e/tests/global-header.spec.ts
+++ b/e2e/tests/global-header.spec.ts
@@ -105,46 +105,44 @@ test.describe("Global Header", () => {
   });
 });
 test.describe("Header drop down interactions", () => {
-  test("Verify Account functionality", async () => {
+  test("Verify Account buttons attributes", async () => {
+    await expect(basePage.goToCatalogLink).not.toBeVisible();
+    await expect(basePage.researchCatalogLink).not.toBeVisible();
     await basePage.myAccountButton.click();
-    const goToCatalogLink = basePage.page.getByRole("link", {
-      name: "Go To The Catalog",
-    });
-    await expect(goToCatalogLink).toBeVisible();
-    const href = await goToCatalogLink.getAttribute("href");
+
+    await expect(basePage.goToCatalogLink).toBeVisible();
+    const href = await basePage.goToCatalogLink.getAttribute("href");
     expect(href).toContain("borrow.nypl.org/?openAccount");
-    const researchCatalogLink = basePage.page.getByRole("link", {
-      name: "Go To The Research Catalog",
-    });
-    await expect(researchCatalogLink).toBeVisible();
-    const researchHref = await researchCatalogLink.getAttribute("href");
+
+    await expect(basePage.researchCatalogLink).toBeVisible();
+    const researchHref =
+      await basePage.researchCatalogLink.getAttribute("href");
     expect(researchHref).toContain("catalog.nypl.org/patroninfo/top");
-    await basePage.page.getByRole("button", { name: "Close" }).click();
+    await basePage.closeAccountButton.click();
+    await expect(basePage.goToCatalogLink).not.toBeVisible();
+    await expect(basePage.researchCatalogLink).not.toBeVisible();
   });
   test('should trap focus within the dropdown when "My Account" is clicked', async () => {
     await basePage.myAccountButton.click();
-
-    const catalog = basePage.page.getByRole("link", {
-      name: "Go To The Catalog",
-    });
-    const research = basePage.page.getByRole("link", {
-      name: "Go To The Research Catalog",
-    });
-    const close = basePage.page.getByRole("button", { name: "Close" });
-
     const isAllowedFocused = async () => {
       const [catalogFocused, researchFocused, closeFocused] = await Promise.all(
         [
-          catalog.evaluate((el) => el === document.activeElement),
-          research.evaluate((el) => el === document.activeElement),
-          close.evaluate((el) => el === document.activeElement),
+          basePage.goToCatalogLink.evaluate(
+            (el) => el === document.activeElement,
+          ),
+          basePage.researchCatalogLink.evaluate(
+            (el) => el === document.activeElement,
+          ),
+          basePage.closeAccountButton.evaluate(
+            (el) => el === document.activeElement,
+          ),
         ],
       );
       return catalogFocused || researchFocused || closeFocused;
     };
 
     // Initial focus set by component logic
-    await expect(catalog).toBeFocused();
+    await expect(basePage.goToCatalogLink).toBeFocused();
 
     await basePage.page.keyboard.press("Tab");
     await expect.poll(isAllowedFocused).toBe(true);

--- a/e2e/tests/global-header.spec.ts
+++ b/e2e/tests/global-header.spec.ts
@@ -246,22 +246,23 @@ test.describe("Search interactions", () => {
       await expect
         .poll(() => {
           const currentUrl = new URL(basePage.page.url());
-
-          return {
-            hostname: currentUrl.hostname,
-            pathname: currentUrl.pathname,
-            searchedFrom: currentUrl.searchParams.get("searched_from"),
-          };
+          return expectedHostnames.includes(currentUrl.hostname);
         })
-        .toEqual(
-          expect.objectContaining({
-            hostname: expect.stringMatching(
-              new RegExp(`^(${expectedHostnames.join("|")})$`),
-            ),
-            pathname: expectedPathname,
-            searchedFrom: "header_search",
-          }),
-        );
+        .toBe(true);
+
+      await expect
+        .poll(() => {
+          const currentUrl = new URL(basePage.page.url());
+          return currentUrl.pathname;
+        })
+        .toBe(expectedPathname);
+
+      await expect
+        .poll(() => {
+          const currentUrl = new URL(basePage.page.url());
+          return currentUrl.searchParams.get("searched_from");
+        })
+        .toBe("header_search");
     });
   }
 });


### PR DESCRIPTION
Fixes [JIRA ticket ISW-5432](http://jira.nypl.org/browse/ISW-5432)

## This PR does the following:

- Added new Search interaction tests in [global-header.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Added focus-trap checks for Search and My Account dropdowns that are stable across browsers.
Added Search destination checks for all 3 search types (catalog, research catalog, website).
Updated URL assertions to verify hostname, pathname, and searched_from=header_search.
Centralized/reused Search locators through [base_page.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Updated radio-option interaction in tests to click visible label text so styled controls work reliably in E2E.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.