### PR TITLE
added permissions block to github workflow file

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Fixes [JIRA ticket ISW-5432](https://newyorkpubliclibrary.atlassian.net/browse/ISW-5432)

## This PR does the following:

- Adds 'permissions: contents: read' to workflow file.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Readme documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.